### PR TITLE
make the max_game_week CTE query also be server specific

### DIFF
--- a/internal/wordle/generated-code/wordle_scores.sql.go
+++ b/internal/wordle/generated-code/wordle_scores.sql.go
@@ -116,15 +116,19 @@ func (q *Queries) GetScoreHistoryByAccount(ctx context.Context, arg GetScoreHist
 }
 
 const getScoresByServerId = `-- name: GetScoresByServerId :many
-with max_game_week as (select max(game_id/7) game_week from wordle_scores)
+with max_game_week as (select max(game_id / 7) game_week
+                       from wordle_scores
+                                inner join nicknames n2 on wordle_scores.discord_id = n2.discord_id
+                       where n2.server_id = $1
+)
 select n.nickname,
        json_agg(guesses order by s.game_id)             guesses_per_game,
        json_agg((7 - s.guesses) ^ 2 order by s.game_id) points_per_game,
        sum((7 - s.guesses) ^ 2)                         total
 from wordle_scores s
          inner join nicknames n on s.discord_id = n.discord_id
-         inner join max_game_week g on g.game_week = s.game_id/7
-where server_id = $1
+         inner join max_game_week g on g.game_week = s.game_id / 7
+where n.server_id = $1
 group by n.nickname
 order by sum((7 - s.guesses) ^ 2) desc
 `

--- a/internal/wordle/query/wordle_scores.sql
+++ b/internal/wordle/query/wordle_scores.sql
@@ -34,14 +34,18 @@ FROM wordle_scores
 WHERE discord_id = $1;
 
 -- name: GetScoresByServerId :many
-with max_game_week as (select max(game_id/7) game_week from wordle_scores)
+with max_game_week as (select max(game_id / 7) game_week
+                       from wordle_scores
+                                inner join nicknames n2 on wordle_scores.discord_id = n2.discord_id
+                       where n2.server_id = $1
+)
 select n.nickname,
        json_agg(guesses order by s.game_id)             guesses_per_game,
        json_agg((7 - s.guesses) ^ 2 order by s.game_id) points_per_game,
        sum((7 - s.guesses) ^ 2)                         total
 from wordle_scores s
          inner join nicknames n on s.discord_id = n.discord_id
-         inner join max_game_week g on g.game_week = s.game_id/7
-where server_id = $1
+         inner join max_game_week g on g.game_week = s.game_id / 7
+where n.server_id = $1
 group by n.nickname
 order by sum((7 - s.guesses) ^ 2) desc;


### PR DESCRIPTION
If one server rolls over to a new week before the others, every scoreboard was going blank since there were no scores for that week