### PR TITLE
Disable/Enable quips on an individual server

### DIFF
--- a/cmd/bot/help.go
+++ b/cmd/bot/help.go
@@ -10,6 +10,8 @@ func helpResponse(s *discordgo.Session, m *discordgo.MessageCreate, botMentionTo
 	response.Text = fmt.Sprintf("`%s` - register a score for the current Wordle game. Only one is score is allowed for each game.\n"+
 		"`%s` - update existing Wordle score for a game\n"+
 		"`%s` - get your past Wordle scores\n"+
+		"`%s` - Turn off quip responses, the bot will continue to add emojis to the request if it understood the input\n"+
+		"`%s` - Turn quip responses back on if previously disabled\n"+
 		"`%s` - Add your own sass for the bot to use as a reply for a specific number\n"+
 		"`%s` - view the scoreboard of you and your friends\n"+
 		"`%s` - view last week's (game number/7) scoreboard\n"+
@@ -18,6 +20,8 @@ func helpResponse(s *discordgo.Session, m *discordgo.MessageCreate, botMentionTo
 		fmt.Sprintf("%s %s 204 5/6 <emoji blocks>", botMentionToken, cmdWordle),
 		fmt.Sprintf("%s %s 204 2/6", botMentionToken, cmdUpdate),
 		fmt.Sprintf("%s %s", botMentionToken, cmdHistory),
+		fmt.Sprintf("%s %s %s", botMentionToken, cmdQuip, cmdQuipDisable),
+		fmt.Sprintf("%s %s %s", botMentionToken, cmdQuip, cmdQuipEnable),
 		fmt.Sprintf("%s %s 3 Wow, you seem really smart!", botMentionToken, cmdQuip),
 		fmt.Sprintf("%s %s", botMentionToken, cmdScoreboard),
 		fmt.Sprintf("%s %s %s", botMentionToken, cmdScoreboard, cmdPreviousWeek),

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -34,6 +34,8 @@ const cmdUpdate = "update"
 const cmdScoreboard = "scoreboard"
 const cmdPreviousWeek = "previous"
 const cmdQuip = "quip"
+const cmdQuipEnable = "enable"
+const cmdQuipDisable = "disable"
 const cmdTimeZone = "timezone"
 const cmdWordle = "Wordle"
 const noSolutionResult = "X"
@@ -157,6 +159,10 @@ func routeMessageToAction(ctx context.Context, s *discordgo.Session, m *discordg
 		updateExistingScore(ctx, m, s, account, gameId, guesses)
 	} else if strings.HasPrefix(input, cmdHistory) {
 		getHistory(ctx, m, s, account)
+	} else if strings.HasPrefix(input, cmdQuip+" "+cmdQuipEnable) {
+		enableQuips(ctx, m, s)
+	} else if strings.HasPrefix(input, cmdQuip+" "+cmdQuipDisable) {
+		disableQuips(ctx, m, s)
 	} else if strings.HasPrefix(input, cmdQuip) {
 		score, quip := extractScoreQuip(input)
 		persistQuip(ctx, m, s, account, score, quip)

--- a/cmd/bot/scores.go
+++ b/cmd/bot/scores.go
@@ -33,6 +33,42 @@ func persistScore(ctx context.Context, m *discordgo.MessageCreate, s *discordgo.
 	flushEmojiAndResponseToDiscord(s, m, response)
 }
 
+func enableQuips(ctx context.Context, m *discordgo.MessageCreate, s *discordgo.Session) {
+	var response response
+
+	q := wordle.New(db)
+	err := q.EnableQuipsForServer(ctx, m.GuildID)
+
+	if err != nil {
+		log.Println(fmt.Sprintf("{'message': 'error enabling quips', 'server_id': %s}", m.GuildID))
+		response.Text = "Error enabling quips"
+		response.Emoji = "💣"
+	}
+
+	response.Text = "Prepare to laugh to death at these mad jokes"
+	response.Emoji = "💭"
+
+	flushEmojiAndResponseToDiscord(s, m, response)
+}
+
+func disableQuips(ctx context.Context, m *discordgo.MessageCreate, s *discordgo.Session) {
+	var response response
+
+	q := wordle.New(db)
+	err := q.DisableQuipsForServer(ctx, m.GuildID)
+
+	if err != nil {
+		log.Println(fmt.Sprintf("{'message': 'error disabling quips', 'server_id': %s}", m.GuildID))
+		response.Text = "Error disabling quips"
+		response.Emoji = "💣"
+	}
+
+	response.Text = "" //No response, only emoji
+	response.Emoji = "😶"
+
+	flushEmojiAndResponseToDiscord(s, m, response)
+}
+
 func persistQuip(ctx context.Context, m *discordgo.MessageCreate, s *discordgo.Session, account wordle.Account, score int, quip string) {
 	var nicknames []wordle.Nickname
 	if m.GuildID == "" {

--- a/cmd/bot/scores.go
+++ b/cmd/bot/scores.go
@@ -239,7 +239,11 @@ func buildScoreObjFromInput(a wordle.Account, gameId int, guesses int) (response
 
 func scoreColorfulResponse(guesses int, ctx context.Context, m *discordgo.MessageCreate) response {
 	var response response
-	response = selectResponseText(guesses, ctx, m, response)
+	q := wordle.New(db)
+	z, _ := q.CheckIfServerHasDisabledQuips(ctx, m.GuildID)
+	if len(z) == 0 {
+		response = selectResponseText(guesses, ctx, m, response)
+	}
 	response = selectResponseEmoji(guesses, response)
 	return response
 }
@@ -253,7 +257,7 @@ func selectResponseText(guesses int, ctx context.Context, m *discordgo.MessageCr
 
 		q := wordle.New(db)
 		r, _ := q.GetQuipByScore(ctx, responseParams)
-		q.IncrementQuip(ctx, r.ID)
+		_ = q.IncrementQuip(ctx, r.ID)
 		response.Text = r.Quip
 	} else if guesses == 69 {
 		response.Text = "nice."

--- a/internal/wordle/generated-code/models.go
+++ b/internal/wordle/generated-code/models.go
@@ -12,6 +12,10 @@ type Account struct {
 	TimeZone  string `json:"time_zone"`
 }
 
+type DisableQuip struct {
+	ServerID string `json:"server_id"`
+}
+
 type Nickname struct {
 	DiscordID string `json:"discord_id"`
 	ServerID  string `json:"server_id"`

--- a/internal/wordle/generated-code/querier.go
+++ b/internal/wordle/generated-code/querier.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Querier interface {
+	CheckIfServerHasDisabledQuips(ctx context.Context, serverID string) (string, error)
 	CountAccountsByDiscordId(ctx context.Context, discordID string) (int64, error)
 	CountNicknameByDiscordIdAndServerId(ctx context.Context, arg CountNicknameByDiscordIdAndServerIdParams) (int64, error)
 	CountScoresByDiscordId(ctx context.Context, discordID string) (int64, error)
@@ -17,6 +18,8 @@ type Querier interface {
 	DeleteAccount(ctx context.Context, discordID string) error
 	DeleteNickname(ctx context.Context, discordID string) error
 	DeleteScoresForUser(ctx context.Context, discordID string) error
+	DisableQuipsForServer(ctx context.Context, serverID string) error
+	EnableQuipsForServer(ctx context.Context, serverID string) error
 	GetAccount(ctx context.Context, discordID string) (Account, error)
 	GetNickname(ctx context.Context, arg GetNicknameParams) (Nickname, error)
 	GetNicknamesByDiscordId(ctx context.Context, discordID string) ([]Nickname, error)

--- a/internal/wordle/query/disable_quips.sql
+++ b/internal/wordle/query/disable_quips.sql
@@ -1,0 +1,10 @@
+-- name: CheckIfServerHasDisabledQuips :one
+SELECT server_id
+from disable_quips
+where server_id = $1;
+
+-- name: DisableQuipsForServer :exec
+insert into disable_quips (server_id) values ($1);
+
+-- name: EnableQuipsForServer :exec
+delete from disable_quips where server_id = $1;

--- a/internal/wordle/schema/20220119205036-disable_quips.sql
+++ b/internal/wordle/schema/20220119205036-disable_quips.sql
@@ -1,0 +1,10 @@
+-- +migrate Up
+create table disable_quips
+(
+    server_id text not null
+);
+
+create index on disable_quips(server_id);
+
+-- +migrate Down
+drop table disable_quips;


### PR DESCRIPTION
```
@Discordle quip disable - Turn off quip responses, the bot will continue to add emojis to the request if it understood the input
@Discordle quip enable - Turn quip responses back on if previously disabled
```

Add two new commands to insert/delete rows in `disable_quips.server_id` table that gets checked before trying to find a hilarious quip to respond with. 