### PR TITLE
Allow collection of Wordle Share blocks without mentioning the bot

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -105,7 +105,8 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	botMentionToken := fmt.Sprintf("@%s", botName)
-	if strings.HasPrefix(tokenizedContent, botMentionToken) {
+	wordleScoreDetected, err := mentionlessWordleScoreDetection(tokenizedContent)
+	if strings.HasPrefix(tokenizedContent, botMentionToken) || wordleScoreDetected {
 		input := strings.TrimSpace(strings.Replace(tokenizedContent, botMentionToken, "", 1))
 		q := wordle.New(db)
 		ctx := context.Background()
@@ -218,6 +219,16 @@ func extractGameGuesses(input string) (int, int, error) {
 		guesses, _ = strconv.Atoi(result["guesses"])
 	}
 	return gameId, guesses, nil
+}
+
+func mentionlessWordleScoreDetection(input string) (bool, error) {
+	var dataExp = regexp.MustCompile(fmt.Sprintf(`Wordle (?P<game_id>\d+)\s(?P<guesses>\d+|%s)/6\n`, noSolutionResult))
+	result, err := matchGroupsToStringMap(input, dataExp)
+	if err != nil {
+		return false, err
+	}
+
+	return len(result) > 0, nil
 }
 
 func matchGroupsToStringMap(input string, dataExp *regexp.Regexp) (map[string]string, error) {

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -40,6 +40,7 @@ const cmdQuipDisable = "disable"
 const cmdTimeZone = "timezone"
 const cmdWordle = "Wordle"
 const noSolutionResult = "X"
+const hardModeIndicator = "*"
 const noSolutionGuesses = 7
 
 func init() {
@@ -222,7 +223,7 @@ func extractGameGuesses(input string) (int, int, error) {
 }
 
 func mentionlessWordleScoreDetection(input string) (bool, error) {
-	var dataExp = regexp.MustCompile(fmt.Sprintf(`Wordle (?P<game_id>\d+)\s(?P<guesses>\d+|%s)/6\n`, noSolutionResult))
+	var dataExp = regexp.MustCompile(fmt.Sprintf(`Wordle (?P<game_id>\d+)\s(?P<guesses>\d+|%s)/6[\%s]?\n`, noSolutionResult, hardModeIndicator))
 	result, err := matchGroupsToStringMap(input, dataExp)
 	if err != nil {
 		return false, err

--- a/cmd/bot/scores.go
+++ b/cmd/bot/scores.go
@@ -26,7 +26,12 @@ func persistScore(ctx context.Context, m *discordgo.MessageCreate, s *discordgo.
 	if err != nil {
 		log.Error().Err(err).Str("server_id", m.GuildID).Str("content", m.Content).Str("author", m.Author.ID).Msg("Failed to persist score")
 		response.Emoji = "⛔"
-		response.Text = "You already created a price for this game, try updating it if it's wrong"
+		serverHasDisabledQuips, _ := q.CheckIfServerHasDisabledQuips(ctx, m.GuildID)
+		if len(serverHasDisabledQuips) == 0 {
+			response.Text = "You already created a score for this game, try updating it if it's wrong"
+		} else {
+			response.Text = ""
+		}
 	} else {
 		response = scoreColorfulResponse(guesses, ctx, m)
 	}
@@ -96,7 +101,7 @@ func persistQuip(ctx context.Context, m *discordgo.MessageCreate, s *discordgo.S
 		_, err := q.CreateQuipForScore(ctx, quipParams)
 		if err != nil {
 			log.Error().Err(err).Str("server_id", m.GuildID).Str("content", m.Content).Str("author", m.Author.ID).Msg("Failed to create quipe")
-			response.Emoji = "⛔"
+			response.Emoji = "⁉️"
 			response.Text = "Them words area not right"
 			flushEmojiAndResponseToDiscord(s, m, response)
 			return
@@ -120,7 +125,7 @@ func getHistory(ctx context.Context, m *discordgo.MessageCreate, s *discordgo.Se
 	var response response
 
 	if err != nil {
-		response.Emoji = "⛔"
+		response.Emoji = "⁉️"
 		response.Text = "Not finding any previous scores"
 	} else {
 		response.Emoji = "👍"
@@ -138,7 +143,7 @@ func getScoreboard(ctx context.Context, m *discordgo.MessageCreate, s *discordgo
 	var response response
 
 	if err != nil {
-		response.Emoji = "⛔"
+		response.Emoji = "⁉️"
 		response.Text = "Not finding any previous scores"
 	} else {
 		response.Emoji = "🔢"
@@ -183,7 +188,7 @@ func getPreviousScoreboard(ctx context.Context, m *discordgo.MessageCreate, s *d
 	var response response
 
 	if err != nil {
-		response.Emoji = "⛔"
+		response.Emoji = "⁉️"
 		response.Text = "Not finding any previous scores"
 	} else {
 		response.Emoji = "🔢"
@@ -216,7 +221,7 @@ func updateExistingScore(ctx context.Context, m *discordgo.MessageCreate, s *dis
 	_, err := q.UpdateScore(ctx, priceParams)
 
 	if err != nil {
-		response.Emoji = "⛔"
+		response.Emoji = "⁉️"
 		response.Text = "I didn't find an existing price."
 	} else {
 		response = scoreColorfulResponse(guesses, ctx, m)
@@ -240,8 +245,8 @@ func buildScoreObjFromInput(a wordle.Account, gameId int, guesses int) (response
 func scoreColorfulResponse(guesses int, ctx context.Context, m *discordgo.MessageCreate) response {
 	var response response
 	q := wordle.New(db)
-	z, _ := q.CheckIfServerHasDisabledQuips(ctx, m.GuildID)
-	if len(z) == 0 {
+	serverHasDisabledQuips, _ := q.CheckIfServerHasDisabledQuips(ctx, m.GuildID)
+	if len(serverHasDisabledQuips) == 0 {
 		response = selectResponseText(guesses, ctx, m, response)
 	}
 	response = selectResponseEmoji(guesses, response)


### PR DESCRIPTION
Uses a pretty specific regex that checks all messages for the `Wordle…\d+ \d/6\n` share block that has to have a new line at the end which is expected if it was pasted from the Wordle Share button.

Exact regex: 
```go
var dataExp = regexp.MustCompile(fmt.Sprintf(`Wordle (?P<game_id>\d+)\s(?P<guesses>\d+|%s)/6\n`, noSolutionResult))
```

This will match bad `@mentions` followed by the share block:
```
@randomName Wordle 200 X/6

⬛⬛⬛⬛⬛
⬛⬛⬛⬛🟩
⬛⬛⬛⬛🟩
⬛⬛⬛⬛🟩
⬛⬛⬛⬛🟩
⬛⬛⬛⬛🟩
```


This will **not match** the phrase `Wordle 200 X/6` in casual conversation since there is no trailing newline, and the bot isn't mentioned.
```
He Tom, I got Wordle 200 X/6 today. Really tough puzzle
```