### PR TITLE
Pad missing days with dashes in scoreboard

### DIFF
--- a/cmd/bot/scores.go
+++ b/cmd/bot/scores.go
@@ -216,6 +216,7 @@ func dashDisplayForMissingScores(expectedGames []int32, v wordle.GetScoresByServ
 func getPreviousScoreboard(ctx context.Context, m *discordgo.MessageCreate, s *discordgo.Session) {
 	q := wordle.New(db)
 	scores, err := q.GetScoresByServerIdPreviousWeek(ctx, m.GuildID)
+	lastWeekExpectedGames, _ := q.GetExpectedPreviousWeekGames(ctx, m.GuildID)
 	var response response
 
 	if err != nil {
@@ -229,7 +230,8 @@ func getPreviousScoreboard(ctx context.Context, m *discordgo.MessageCreate, s *d
 
 		_, _ = fmt.Fprintln(w, "Name\tGuesses\tTotal\t")
 		for _, v := range scores {
-			_, _ = fmt.Fprintln(w, fmt.Sprintf("%s\t%s\t%d\t", v.Nickname, v.GuessesPerGame, v.Total))
+			displayGameGuesses := dashDisplayForMissingScores(lastWeekExpectedGames, wordle.GetScoresByServerIdRow(v))
+			_, _ = fmt.Fprintln(w, fmt.Sprintf("%s\t%s\t%d\t", v.Nickname, displayGameGuesses, v.Total))
 		}
 
 		_ = w.Flush()

--- a/internal/wordle/generated-code/db.go
+++ b/internal/wordle/generated-code/db.go
@@ -64,6 +64,12 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAccountStmt, err = db.PrepareContext(ctx, getAccount); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAccount: %w", err)
 	}
+	if q.getExpectedPreviousWeekGamesStmt, err = db.PrepareContext(ctx, getExpectedPreviousWeekGames); err != nil {
+		return nil, fmt.Errorf("error preparing query GetExpectedPreviousWeekGames: %w", err)
+	}
+	if q.getExpectedWeekGamesStmt, err = db.PrepareContext(ctx, getExpectedWeekGames); err != nil {
+		return nil, fmt.Errorf("error preparing query GetExpectedWeekGames: %w", err)
+	}
 	if q.getNicknameStmt, err = db.PrepareContext(ctx, getNickname); err != nil {
 		return nil, fmt.Errorf("error preparing query GetNickname: %w", err)
 	}
@@ -179,6 +185,16 @@ func (q *Queries) Close() error {
 	if q.getAccountStmt != nil {
 		if cerr := q.getAccountStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAccountStmt: %w", cerr)
+		}
+	}
+	if q.getExpectedPreviousWeekGamesStmt != nil {
+		if cerr := q.getExpectedPreviousWeekGamesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getExpectedPreviousWeekGamesStmt: %w", cerr)
+		}
+	}
+	if q.getExpectedWeekGamesStmt != nil {
+		if cerr := q.getExpectedWeekGamesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getExpectedWeekGamesStmt: %w", cerr)
 		}
 	}
 	if q.getNicknameStmt != nil {
@@ -304,6 +320,8 @@ type Queries struct {
 	disableQuipsForServerStmt               *sql.Stmt
 	enableQuipsForServerStmt                *sql.Stmt
 	getAccountStmt                          *sql.Stmt
+	getExpectedPreviousWeekGamesStmt        *sql.Stmt
+	getExpectedWeekGamesStmt                *sql.Stmt
 	getNicknameStmt                         *sql.Stmt
 	getNicknamesByDiscordIdStmt             *sql.Stmt
 	getQuipByScoreStmt                      *sql.Stmt
@@ -338,6 +356,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		disableQuipsForServerStmt:               q.disableQuipsForServerStmt,
 		enableQuipsForServerStmt:                q.enableQuipsForServerStmt,
 		getAccountStmt:                          q.getAccountStmt,
+		getExpectedPreviousWeekGamesStmt:        q.getExpectedPreviousWeekGamesStmt,
+		getExpectedWeekGamesStmt:                q.getExpectedWeekGamesStmt,
 		getNicknameStmt:                         q.getNicknameStmt,
 		getNicknamesByDiscordIdStmt:             q.getNicknamesByDiscordIdStmt,
 		getQuipByScoreStmt:                      q.getQuipByScoreStmt,

--- a/internal/wordle/generated-code/querier.go
+++ b/internal/wordle/generated-code/querier.go
@@ -21,6 +21,8 @@ type Querier interface {
 	DisableQuipsForServer(ctx context.Context, serverID string) error
 	EnableQuipsForServer(ctx context.Context, serverID string) error
 	GetAccount(ctx context.Context, discordID string) (Account, error)
+	GetExpectedPreviousWeekGames(ctx context.Context, serverID string) ([]int32, error)
+	GetExpectedWeekGames(ctx context.Context, serverID string) ([]int32, error)
 	GetNickname(ctx context.Context, arg GetNicknameParams) (Nickname, error)
 	GetNicknamesByDiscordId(ctx context.Context, discordID string) ([]Nickname, error)
 	GetQuipByScore(ctx context.Context, arg GetQuipByScoreParams) (Quip, error)

--- a/internal/wordle/testData/fake_scores.sql
+++ b/internal/wordle/testData/fake_scores.sql
@@ -13,6 +13,7 @@ VALUES ('1', '934007495737884712', '1'),
        ('4', '934007495737884712', '4'),
        ('5', '934007495737884712', '5'),
        ('6', '934007495737884712', '6');
+-- Week 129
 insert into wordle_scores (discord_id, game_id, guesses)
 VALUES ('1', 903, 1),
        ('1', 904, 1),
@@ -41,4 +42,11 @@ VALUES ('5', 907, 5),
 insert into wordle_scores (discord_id, game_id, guesses)
 VALUES ('6', 908, 6);
 
+-- Week 129
+insert into wordle_scores (discord_id, game_id, guesses)
+VALUES ('6', 910, 6);
+insert into wordle_scores (discord_id, game_id, guesses)
+VALUES ('1', 910, 1),
+       ('1', 911, 1);
+delete from wordle_scores where game_id = 911;
 commit;

--- a/internal/wordle/testData/fake_scores.sql
+++ b/internal/wordle/testData/fake_scores.sql
@@ -1,0 +1,44 @@
+begin;
+insert into accounts (discord_id)
+values ('1'),
+       ('2'),
+       ('3'),
+       ('4'),
+       ('5'),
+       ('6');
+insert into nicknames (discord_id, server_id, nickname)
+VALUES ('1', '934007495737884712', '1'),
+       ('2', '934007495737884712', '2'),
+       ('3', '934007495737884712', '3'),
+       ('4', '934007495737884712', '4'),
+       ('5', '934007495737884712', '5'),
+       ('6', '934007495737884712', '6');
+insert into wordle_scores (discord_id, game_id, guesses)
+VALUES ('1', 903, 1),
+       ('1', 904, 1),
+       ('1', 905, 1),
+       ('1', 906, 1),
+       ('1', 907, 1),
+       ('1', 908, 1);
+insert into wordle_scores (discord_id, game_id, guesses)
+VALUES ('2', 903, 2),
+       ('2', 904, 2),
+       ('2', 905, 2),
+       ('2', 906, 2),
+       ('2', 907, 2);
+insert into wordle_scores (discord_id, game_id, guesses)
+VALUES ('3', 903, 3),
+       ('3', 904, 3),
+       ('3', 907, 3),
+       ('3', 908, 3);
+insert into wordle_scores (discord_id, game_id, guesses)
+VALUES ('4', 903, 4),
+       ('4', 907, 4),
+       ('4', 908, 4);
+insert into wordle_scores (discord_id, game_id, guesses)
+VALUES ('5', 907, 5),
+       ('5', 908, 5);
+insert into wordle_scores (discord_id, game_id, guesses)
+VALUES ('6', 908, 6);
+
+commit;


### PR DESCRIPTION
Implementation for #22 

Before: 
```
Name   Guesses              Total   
1      [1, 1, 1, 1, 1, 1]   216     
2      [2, 2, 2, 2, 2]      125     
3      [3, 3, 3, 3]         64      
4      [4, 4, 4]            27      
5      [5, 5]               8       
6      [6]                  1 
```

After:
```
Name   Guesses         Total   
1      [1 1 1 1 1 1]   216     
2      [2 2 2 2 2 -]   125     
3      [3 3 - - 3 3]   64      
4      [4 - - - 4 4]   27      
5      [- - - - 5 5]   8       
6      [- - - - - 6]   1 
```

Code explanation:
I tried a SQL-only solution, but the left wasn't returning null rows/values like I needed for the `coalesce()` operator needed to work. Instead, I had to pull the list of possible games into the app and iterate through each one and choose to display the number if it's defined, otherwise using `-` placeholder.

Not as pretty as I wanted since I had to add two new layer of loops, and even the return format from the database `[{"217" : 5}, {"218" : 5}, {"219" : 6}]` isn't the ideal shape of a flat dictionary `{"271": 5, "218": 5, "219": 6}` so I had to repack that data in the new `dashDisplayForMissingScores` method.